### PR TITLE
Feature/of 700 fix react hook form validation errors not displaying in

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -44,7 +44,11 @@
     "invalidAddress": "Invalid address",
     "numberRequired": "Please enter a number",
     "positiveNumber": "Please enter a positive number",
-    "slugFormat": "Only lowercase letters, numbers, and hyphens are allowed"
+    "slugFormat": "Only lowercase letters, numbers, and hyphens are allowed",
+    "titleRequired": "Title is required",
+    "titleMax": "Title cannot be longer than 32 characters",
+    "descriptionMin": "Description must be at least 3 characters",
+    "slugRequired": "Slug is required"
   },
   "navigation": {
     "menu": {
@@ -195,10 +199,11 @@
         "userRequired": "User handle is required",
         "tokenRequired": "Token is required",
         "amountMin": "Amount must be at least 0.000000000000000001",
+        "amountRequired": "Amount is required",
         "rewardIdMin": "Reward ID must be at least 3 characters",
         "keyRequired": "Key is required",
         "valueRequired": "Value is required",
-        "insufficientBalance": "Insufficient balance. Max available: {balance} tokens"
+        "insufficientBalance": "Insufficient balance. You have {balance} tokens available"
       },
       "fields": {
         "rewardId": {
@@ -714,6 +719,8 @@
         }
       },
       "validation": {
+        "titleRequired": "Title is required",
+        "titleMax": "Title cannot be longer than 32 characters",
         "descriptionMin": "Description must be at least 3 characters",
         "slugRequired": "Slug is required",
         "invalidImageUrl": "Please provide a valid image URL",

--- a/messages/en.json
+++ b/messages/en.json
@@ -727,7 +727,8 @@
         "nameRequired": "Name is required",
         "pointsRequired": "Points are required",
         "pointsMin": "Points must be at least 1",
-        "invalidColorHex": "Invalid color hex code"
+        "invalidColorHex": "Invalid color hex code",
+        "descriptionMax": "Description cannot be longer than 2000 characters"
       }
     }
   },

--- a/src/forms/community-settings-form.tsx
+++ b/src/forms/community-settings-form.tsx
@@ -33,15 +33,19 @@ export default function CommunitySettingsForm({
   const t = useTranslations('settings.form');
 
   const FormSchema = z.object({
-    title: z.string().min(0).max(32),
-    description: z.string().min(3, t('validation.descriptionMin')).optional().or(z.literal("")),
+    title: z.string()
+      .min(1, t('validation.titleRequired'))
+      .max(32, t('validation.titleMax')),
+    description: z.string()
+      .min(3, t('validation.descriptionMin'))
+      .optional()
+      .or(z.literal("")),
     accent_color: z.string().min(3),
     user_label: z.string().min(3),
     token_label: z.string().min(3),
     dark_mode: z.boolean().default(false),
     token_to_display: z.string().min(3),
-    slug: z
-      .string()
+    slug: z.string()
       .min(1, t('validation.slugRequired'))
       .transform((str) =>
         str
@@ -77,6 +81,7 @@ export default function CommunitySettingsForm({
 
   const form = useForm<FormValues>({
     resolver: zodResolver(FormSchema),
+    mode: "onBlur",
     defaultValues: {
       title: community.metadata?.title ?? "",
       description: community.metadata?.description ?? "",
@@ -151,7 +156,13 @@ export default function CommunitySettingsForm({
                       <FormItem>
                         <FormLabel>{t('sections.general.fields.name.label')}</FormLabel>
                         <FormControl>
-                          <Input placeholder={t('sections.general.fields.name.placeholder')} {...field} />
+                          <Input 
+                            placeholder={t('sections.general.fields.name.placeholder')} 
+                            {...field}
+                            onBlur={(e) => {
+                              field.onBlur();
+                            }}
+                          />
                         </FormControl>
                         <FormMessage />
                         <FormDescription>{t('sections.general.fields.name.description')}</FormDescription>
@@ -166,7 +177,13 @@ export default function CommunitySettingsForm({
                       <FormItem>
                         <FormLabel>{t('sections.general.fields.description.label')}</FormLabel>
                         <FormControl>
-                          <Textarea placeholder={t('sections.general.fields.description.placeholder')} {...field} />
+                          <Textarea 
+                            placeholder={t('sections.general.fields.description.placeholder')} 
+                            {...field}
+                            onBlur={(e) => {
+                              field.onBlur();
+                            }}
+                          />
                         </FormControl>
                         <FormMessage />
                         <FormDescription>{t('sections.general.fields.description.description')}</FormDescription>
@@ -185,6 +202,7 @@ export default function CommunitySettingsForm({
                             placeholder={t('sections.general.fields.slug.placeholder')}
                             {...field}
                             onBlur={async (e) => {
+                              field.onBlur();
                               const transformed = e.target.value
                                 .toLowerCase()
                                 .trim()
@@ -192,15 +210,18 @@ export default function CommunitySettingsForm({
                                 .replace(/^-+|-+$/g, "");
                               field.onChange(transformed);
 
-                              if (transformed === community.metadata.slug) return;
-
-                              const isAvailable = await isSlugAvailable(transformed, community.id);
-                              if (!isAvailable) {
-                                form.setError("slug", {
-                                  message: t('messages.slugTaken'),
-                                });
-                              } else {
-                                form.clearErrors("slug");
+                              // Only check availability if there's a value and it's different from current
+                              if (transformed && transformed !== community.metadata.slug) {
+                                const isAvailable = await isSlugAvailable(transformed, community.id);
+                                if (!isAvailable) {
+                                  form.setError("slug", {
+                                    message: t('messages.slugTaken'),
+                                  });
+                                }
+                                // Only clear errors if we're checking availability
+                                else if (form.getFieldState('slug').error?.message === t('messages.slugTaken')) {
+                                  form.clearErrors("slug");
+                                }
                               }
                             }}
                           />

--- a/src/forms/community-settings-form.tsx
+++ b/src/forms/community-settings-form.tsx
@@ -37,7 +37,8 @@ export default function CommunitySettingsForm({
       .min(1, t('validation.titleRequired'))
       .max(32, t('validation.titleMax')),
     description: z.string()
-      .min(3, t('validation.descriptionMin'))
+      .min(3, t("validation.descriptionMin"))
+      .max(2000, t("validation.descriptionMax"))
       .optional()
       .or(z.literal("")),
     accent_color: z.string().min(3),


### PR DESCRIPTION
## Problem
The community settings form had several validation and user feedback issues:
1. Form validation errors weren't being displayed to users
2. Slug validation errors would disappear prematurely
4. Missing translation keys for validation messages

## Solution
Updated the community settings form to:
1. Add proper field connections using `{...field}` spread operator
2. Fix slug validation to persist error messages appropriately
4. Add missing translation keys for validation messages

<img width="553" alt="Screenshot 2025-02-11 at 10 39 07" src="https://github.com/user-attachments/assets/52f97fb5-21d3-40e7-86e9-eded162cfcde" />
<img width="577" alt="Screenshot 2025-02-11 at 10 38 52" src="https://github.com/user-attachments/assets/b4bf15c4-c9b3-4ba7-aeda-423b1b6a4313" />
<img width="937" alt="Screenshot 2025-02-10 at 15 03 30" src="https://github.com/user-attachments/assets/75554d03-13a3-4703-b649-b10928b008ee" />
