### PR TITLE
feat: Improve CommunityInfo component accessibility and structure

### DIFF
--- a/src/components/community-info.tsx
+++ b/src/components/community-info.tsx
@@ -16,7 +16,7 @@ export default function CommunityInfo({ title, description }: CommunityInfoProps
     const paragraphs = description.split("\n\n").filter((p) => p.trim() !== "");
 
     return (
-      <div>
+      <div aria-label={t("ariaLabels.description")}>
         {paragraphs.map((paragraph, index) => (
           <p key={index} className="mb-2">
             {paragraph}
@@ -32,9 +32,7 @@ export default function CommunityInfo({ title, description }: CommunityInfoProps
         <h1 className="text-2xl font-bold" aria-label={t("ariaLabels.title")}>
           {title}
         </h1>
-        <p className="text-sm" aria-label={t("ariaLabels.description")}>
-          <FormattedDescription description={description} />
-        </p>
+        <FormattedDescription description={description} />
       </CardHeader>
     </Card>
   );


### PR DESCRIPTION
## Problem
In html, a `<div>` tag can't be descendant of `<p>` tag.

<img width="971" alt="Screenshot 2025-02-13 at 18 59 19" src="https://github.com/user-attachments/assets/8474051f-391a-46fb-b7f3-43daf459c55a" />



## Solution
- Added aria-label to description div
- Removed redundant paragraph wrapper for FormattedDescription
- Simplified component markup while maintaining semantic structure
