### PR TITLE
feat: add Telegram account linking functionality

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -344,6 +344,26 @@
       "connect": "Connect {service} account",
       "connected": "Connected to {service} as {username}",
       "disconnect": "Disconnect {service} account"
+    },
+    "discord": {
+      "connect": "Connect Discord",
+      "connected": "Connected to Discord"
+    },
+    "github": {
+      "connect": "Connect Github",
+      "connected": "Connected to Github"
+    },
+    "telegram": {
+      "connect": "Connect Telegram",
+      "connected": "Connected to Telegram",
+      "errors": {
+        "linkFailed": "Failed to connect Telegram",
+        "unlinkFailed": "Failed to disconnect Telegram"
+      },
+      "ariaLabels": {
+        "connect": "Connect Telegram account",
+        "disconnect": "Disconnect Telegram account"
+      }
     }
   },
   "activity": {

--- a/src/components/accounts.tsx
+++ b/src/components/accounts.tsx
@@ -6,11 +6,23 @@ import { useTranslations } from 'next-intl';
 import Image from "next/image";
 import Discord from "../../public/icons/discord.svg";
 import Google from "../../public/icons/google.svg";
+import Telegram from "../../public/icons/telegram.svg";
 import { Button } from "./ui/button";
+import { toast } from "sonner";
 
 export default function Accounts() {
   const t = useTranslations('accounts');
-  const { user, linkDiscord, unlinkDiscord, linkGoogle, unlinkGoogle, linkEmail, unlinkEmail } = usePrivy();
+  const { 
+    user, 
+    linkDiscord, 
+    unlinkDiscord, 
+    linkGoogle, 
+    unlinkGoogle, 
+    linkEmail, 
+    unlinkEmail,
+    linkTelegram,
+    unlinkTelegram 
+  } = usePrivy();
 
   const platforms = [
     {
@@ -19,6 +31,14 @@ export default function Accounts() {
       unlink: () => unlinkDiscord(user?.discord?.subject ?? "").catch((error) => alert(error.message)),
       username: user?.discord?.username,
       icon: <Image src={Discord} alt="Discord" width={20} height={20} className="fill-[#5865F2]" />,
+    },
+    {
+      id: "telegram",
+      link: linkTelegram,
+      unlink: () => unlinkTelegram(user?.telegram?.subject ?? "")
+        .catch((error) => toast.error(t('telegram.errors.unlinkFailed'))),
+      username: user?.telegram?.username,
+      icon: <Image src={Telegram} alt={t('telegram.connect')} width={20} height={20} className="fill-[#2CA5E0]" />,
     },
     {
       id: "google",
@@ -51,10 +71,10 @@ export default function Accounts() {
                 size="sm" 
                 onClick={platform.link} 
                 className="p-0 hover:bg-transparent"
-                aria-label={t('ariaLabels.connect', { service: platform.id })}
+                aria-label={t(`${platform.id}.ariaLabels.connect`)}
               >
                 <span className="capitalize font-semibold hover:underline">
-                  {t('connect', { service: platform.id })}
+                  {t(`${platform.id}.connect`)}
                 </span>
               </Button>
             )}

--- a/src/components/link-accounts.tsx
+++ b/src/components/link-accounts.tsx
@@ -7,10 +7,22 @@ import { useTranslations } from 'next-intl';
 import Image from "next/image";
 import Discord from "../../public/icons/discord.svg";
 import Github from "../../public/icons/github.svg";
+import Telegram from "../../public/icons/telegram.svg";
 
 export default function LinkAccounts() {
   const t = useTranslations('accounts');
-  const { user, linkDiscord, unlinkDiscord, ready, linkGithub, unlinkGithub, login, authenticated } = usePrivy();
+  const { 
+    user, 
+    linkDiscord, 
+    unlinkDiscord, 
+    linkGithub, 
+    unlinkGithub,
+    linkTelegram,
+    unlinkTelegram,
+    ready, 
+    login, 
+    authenticated 
+  } = usePrivy();
 
   const services = [
     {
@@ -30,6 +42,15 @@ export default function LinkAccounts() {
       },
       icon: <Image src={Github} alt="Github" width={20} height={20} />,
       linkedAccount: user?.github?.username,
+    },
+    {
+      id: "telegram",
+      actions: {
+        link: linkTelegram,
+        unlink: unlinkTelegram,
+      },
+      icon: <Image src={Telegram} alt="Telegram" width={20} height={20} />,
+      linkedAccount: user?.telegram?.username,
     },
   ];
 


### PR DESCRIPTION
Problem:
Platform lacks Telegram integration, limiting social connection options for users.

Solution:
Added Telegram account linking using Privy's authentication flow, matching existing Discord/GitHub implementation with proper error handling and translations.
<img width="740" alt="Screenshot 2025-03-06 at 11 54 46" src="https://github.com/user-attachments/assets/e0344695-cc0e-46ac-8078-f57d6fe4bcce" />
