### PR TITLE
chore: Remove showWalletLoginFirst option from wallet configuration

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -45,7 +45,6 @@ export default function Providers({
           defaultChain: arbitrumSepolia,
 
           appearance: {
-            showWalletLoginFirst: true,
             walletChainType: "ethereum-only",
             walletList: ["metamask", "wallet_connect", "rainbow", "rabby_wallet"],
           },


### PR DESCRIPTION
### Description
This PR prioritises social logins over wallet logins by removing `showWalletLoginFirst` setting in `PrivyProvider`

![login-order-prioritise-socials](https://github.com/user-attachments/assets/2e4fd899-9397-4994-af9e-4cbda7ffb613)


