### PR TITLE
fix/ fixed badge support in token selector drop down

### DIFF
--- a/src/components/token-selector.tsx
+++ b/src/components/token-selector.tsx
@@ -36,17 +36,23 @@ export default function TokenSelector({
   const t = useTranslations('tokenSelector');
 
   React.useEffect(() => {
-    if (value && !tokens.some(token => token.token.id === value)) {
+    if (value && 
+        !tokens.some(token => token.token.id === value) && 
+        !badges.some(badge => badge.id === value)) {
       onChange("");
     }
-  }, [tokens, value, onChange]);
+  }, [tokens, badges, value, onChange]);
 
   const handleSelect = (currentValue: string) => {
-    const newValue = currentValue === value ? "" : currentValue;
-    onChange(newValue);
+    console.log('HandleSelect - Current:', currentValue);
+    console.log('HandleSelect - Previous:', value);
+    
+    // Always update with the new value
+    onChange(currentValue);
 
     if (onTokenTypeChange) {
-      const isBadge = badges.some((badge) => badge.id === newValue);
+      const isBadge = badges.some((badge) => badge.id === currentValue);
+      console.log('Is Badge:', isBadge);
       onTokenTypeChange(isBadge);
     }
 
@@ -61,10 +67,22 @@ export default function TokenSelector({
   };
 
   const getDisplayValue = () => {
-    const selectedItem = [...tokens, ...badges].find((item) => item.token?.id === value);
-    if (selectedItem) {
-      return `${selectedItem.token?.name} (${selectedItem.token?.id})`;
+    // Debug the display value calculation
+    const selectedBadge = badges.find((badge) => badge.id === value);
+    const selectedToken = tokens.find((item) => item.token?.id === value);
+    
+    console.log('GetDisplayValue - Selected Badge:', selectedBadge);
+    console.log('GetDisplayValue - Selected Token:', selectedToken);
+    console.log('GetDisplayValue - Current Value:', value);
+
+    if (selectedBadge) {
+      return selectedBadge.name;
     }
+    
+    if (selectedToken) {
+      return `${selectedToken.token?.name} (${selectedToken.token?.id})`;
+    }
+    
     if (isAddress(value)) {
       return value;
     }
@@ -103,10 +121,20 @@ export default function TokenSelector({
             </CommandEmpty>
             <CommandGroup heading={t('tokens')}>
               {tokens.map((item) => (
-                <CommandItem key={item.token.id} value={item.token.name} onSelect={() => handleSelect(item.token.id)}>
-                  <CircleDollarSign className={cn("mr-2 h-4 w-4", value === item.id ? "opacity-100" : "opacity-40")} />
-                  {`${item.token.name} (${addressSplitter(item.token.id, 4)})`}
-                  <Check className={cn("ml-auto h-4 w-4", value === item.id ? "opacity-100" : "opacity-0")} />
+                <CommandItem
+                  key={item.token.id}
+                  value={item.token.name}
+                  onSelect={() => handleSelect(item.token.id)}
+                >
+                  <CircleDollarSign className={cn(
+                    "mr-2 h-4 w-4",
+                    value === item.token.id ? "opacity-100" : "opacity-40"
+                  )} />
+                  {item.token.name}
+                  <Check className={cn(
+                    "ml-auto h-4 w-4",
+                    value === item.token.id ? "opacity-100" : "opacity-0"
+                  )} />
                 </CommandItem>
               ))}
             </CommandGroup>

--- a/src/forms/rewards-form.tsx
+++ b/src/forms/rewards-form.tsx
@@ -88,10 +88,12 @@ export default function RewardsForm({ community }: { community: Community }) {
 
   useEffect(() => {
     async function fetchTokenBalance() {
-      if (user?.wallet?.address && form.watch("tokenAddress")) {
+      const tokenAddress = form.watch("tokenAddress");
+      // Only fetch balance if it's a token, not a badge
+      if (user?.wallet?.address && tokenAddress && !isSelectedBadge(tokenAddress)) {
         try {
           const balance = await readContract(config, {
-            address: form.watch("tokenAddress") as Address,
+            address: tokenAddress as Address,
             abi: erc20Abi,
             functionName: "balanceOf",
             args: [user.wallet.address as Address],
@@ -107,7 +109,7 @@ export default function RewardsForm({ community }: { community: Community }) {
     }
 
     fetchTokenBalance();
-  }, [user?.wallet?.address, form.watch("tokenAddress"), config]);
+  }, [user?.wallet?.address, form.watch("tokenAddress"), config, isSelectedBadge]);
 
   function onSubmit(data: z.infer<typeof rewardsFormSchema>) {
     try {


### PR DESCRIPTION
# Fix Badge Selection in Token Selector

## Problem
Badge selections in the TokenSelector component were not persisting. When a badge was selected, the component's useEffect hook was clearing the selection because it only checked for tokens, not badges.

## Solution
Updated the useEffect hook in TokenSelector to check for both tokens and badges before clearing the selection value:
Updated TokenSelector to not make unnecessary actions if selected option is a badge