### PR TITLE
Fix/leaderboard date range bug

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -172,12 +172,11 @@
       "token": "Token",
       "datePicker": {
         "pickDate": "Pick a Date",
-        "custom": "Custom",
-        "thisMonth": "This Month",
-        "lastMonth": "Last Month",
-        "threeMonths": "Three Months",
-        "allTime": "All time",
-        "lastWeek": "Last Week"
+        "today": "Today",
+        "last7Days": "Last 7 Days",
+        "last30Days": "Last 30 Days",
+        "last90Days": "Last 90 Days",
+        "filterByDate": "Filter by Date"
       }
     },
     "activity": {
@@ -298,7 +297,6 @@
         "parseError": "Row: {row}: {message}",
         "rewardError": "Reward #{row}: {message}",
         "tokenNotFound": "Token {tokenName} not found in current community {communityName}"
-
       },
       "fields": {
         "csvFile": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -175,6 +175,7 @@
         "today": "Today",
         "last7Days": "Last 7 Days",
         "last30Days": "Last 30 Days",
+        "last60Days": "Last 60 Days",
         "last90Days": "Last 90 Days",
         "filterByDate": "Filter by Date"
       }

--- a/src/components/date-picker.tsx
+++ b/src/components/date-picker.tsx
@@ -67,6 +67,7 @@ export default function DatePickerWithPresets({ onDateChange }: DatePickerProps)
             <SelectItem value="0">{t("datePicker.today")}</SelectItem>
             <SelectItem value="6">{t("datePicker.last7Days")}</SelectItem>
             <SelectItem value="29">{t("datePicker.last30Days")}</SelectItem>
+            <SelectItem value="59">{t("datePicker.last60Days")}</SelectItem>
             <SelectItem value="89">{t("datePicker.last90Days")}</SelectItem>
           </SelectContent>
         </Select>

--- a/src/components/date-picker.tsx
+++ b/src/components/date-picker.tsx
@@ -1,53 +1,43 @@
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import dayjs from "dayjs";
+import { CalendarIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
-import { DateRange } from "react-day-picker";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
-import { CalendarIcon } from "lucide-react";
-import { format } from "date-fns";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Calendar } from "@/components/ui/calendar";
+import type { DateRange } from "react-day-picker";
 
 interface DatePickerProps {
   onDateChange: (date: DateRange | undefined) => void;
 }
 
-export default function DatePickerWithPresets({onDateChange}: DatePickerProps) {
-  const today = new Date();
-  const t = useTranslations( "overview.leaderboard" );
-  const [date, setDate] = useState<DateRange | undefined>( {
-    from: new Date( new Date().setDate( today.getDate() - 7 ) ),
-    to: new Date(),
-  } );
-  const [preset, setPreset] = useState<string>( "5" );
-  const [startMonth, setStartMonth] = useState( new Date( new Date().setDate( today.getDate() - 30 ) ) );
-  const [endMonth, setEndMonth] = useState( new Date() );
-  const presets = {
-    "0": "Last month",
-    "1": "This month",
-    "2": "Three months",
-    "3": "All time",
-    "4": "Custom",
-    "5": "Last week",
-  };
+export default function DatePickerWithPresets({ onDateChange }: DatePickerProps) {
+  const t = useTranslations("overview.leaderboard");
+  const [date, setDate] = useState<DateRange | undefined>({
+    from: dayjs().subtract(6, "day").toDate(),
+    to: dayjs().endOf("day").toDate(),
+  });
 
-  const daysAgo = (n: number) => {
-    const d = new Date();
-    d.setDate( d.getDate() - Math.abs( n ) );
-    return d;
-  };
-
-  const onDayClick = (day: DateRange | undefined) => {
-    setDate( day );
-    setPreset( "4" );
-  };
-
-  useEffect( () => {
+  useEffect(() => {
     if (date?.to && date.from && onDateChange) {
-      onDateChange( date );
+      onDateChange({ from: date.from, to: new Date(date.to.setHours(23, 59, 59, 999)) });
     }
-  }, [date] );
+  }, [date]);
+
+  function handlePresetChange(value: string) {
+    setDate({
+      from: dayjs().subtract(Number.parseInt(value), "day").toDate(),
+      to: dayjs().endOf("day").toDate(),
+    });
+  }
 
   return (
     <Popover>
@@ -56,110 +46,42 @@ export default function DatePickerWithPresets({onDateChange}: DatePickerProps) {
           variant={"outline"}
           className={cn(
             "w-[240px] justify-start text-left font-normal",
-            !date && "text-muted-foreground"
+            !date && "text-muted-foreground",
           )}
         >
-          <CalendarIcon/>
+          <CalendarIcon />
           {date?.from ? (
-            date.to ? (
-              <>
-                {format( date.from, "LLL dd, y" )} -{" "}
-                {format( date.to, "LLL dd, y" )}
-              </>
-            ) : (
-              format( date.from, "LLL dd, y" )
-            )
+            dayjs(date.from).format("MMM DD, YYYY") +
+            (date.to ? ` - ${dayjs(date.to).format("MMM DD, YYYY")}` : "")
           ) : (
-            <span>{t( "datePicker.pickDate" )}</span>
+            <span>{t("datePicker.pickDate")}</span>
           )}
         </Button>
       </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        className="flex w-auto flex-col space-y-2 p-2"
-      >
-        <Select
-          value={preset}
-          onValueChange={(value) => {
-            if (value === "0") {
-              const newFrom = daysAgo( 30 );
-              const newDate: DateRange = {
-                from: newFrom,
-                to: today,
-              };
-              setDate( newDate );
-              setStartMonth( newFrom );
-              setEndMonth( today );
-              setPreset( "0" );
-            } else if (value === '1') {
-              const thisMonth = new Date( today.getFullYear(), today.getMonth(), 1 );
-              const newDate: DateRange = {
-                from: thisMonth,
-                to: today,
-              };
-              setDate( newDate );
-              setStartMonth( thisMonth );
-              setPreset( "1" );
-            } else if (value === "2") {
-              const newFrom = daysAgo( 90 );
-              const newDate: DateRange = {
-                from: newFrom,
-                to: today,
-              };
-              setDate( newDate );
-              setStartMonth( newFrom )
-              setEndMonth( today );
-              setPreset( "2" );
-            } else if (value === "3") {
-              const newDate: DateRange = {
-                from: new Date( 2022, 3, 2 ),
-                to: today,
-              };
-              setDate( newDate );
-              setStartMonth( new Date( 2022, 3, 2 ) )
-              setEndMonth( today );
-              setPreset( "3" );
-            } else if (value === "5") {
-              const newFrom = daysAgo( 7 );
-              const newDate: DateRange = {
-                from: newFrom,
-                to: today,
-              };
-              setDate( newDate );
-              setStartMonth( newFrom )
-              setEndMonth( today );
-              setPreset( "5" );
-            }
-          }
-          }
-        >
+      <PopoverContent align="start" className="flex w-auto flex-col space-y-2 p-2">
+        <Select onValueChange={handlePresetChange} defaultValue="6">
           <SelectTrigger>
-            <SelectValue placeholder={presets[preset]}/>
+            <SelectValue placeholder={t("datePicker.pickDate")} />
           </SelectTrigger>
           <SelectContent position="popper">
-            <SelectItem value="4">{t( "datePicker.custom" )}</SelectItem>
-            <SelectItem value="5">{t( "datePicker.lastWeek" )}</SelectItem>
-            <SelectItem value="1">{t( "datePicker.thisMonth" )}</SelectItem>
-            <SelectItem value="0">{t( "datePicker.lastMonth" )}</SelectItem>
-            <SelectItem value="2">{t( "datePicker.threeMonths" )}</SelectItem>
-            <SelectItem value="3">{t( "datePicker.allTime" )}</SelectItem>
+            <SelectItem value="0">{t("datePicker.today")}</SelectItem>
+            <SelectItem value="6">{t("datePicker.last7Days")}</SelectItem>
+            <SelectItem value="29">{t("datePicker.last30Days")}</SelectItem>
+            <SelectItem value="89">{t("datePicker.last90Days")}</SelectItem>
           </SelectContent>
         </Select>
         <div className="rounded-md border">
           <Calendar
             initialFocus={true}
             mode="range"
-            month={startMonth}
-            endMonth={endMonth}
             selected={date}
-            onSelect={onDayClick}
-            onMonthChange={setStartMonth}
+            defaultMonth={date?.from}
+            onSelect={setDate}
             numberOfMonths={2}
-            required
-            disabled={{after: new Date(), before: new Date( 2022, 3, 2 )}}
+            disabled={{ after: new Date(), before: new Date(2022, 3, 2) }}
           />
         </div>
       </PopoverContent>
     </Popover>
-  )
-};
+  );
+}

--- a/src/components/leaderboard.tsx
+++ b/src/components/leaderboard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import DatePickerWithPresets from "@/components/date-picker";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import {
@@ -20,17 +21,16 @@ import {
 import { generateLeaderboard } from "@/lib/openformat";
 import { cn, filterVisibleTokens } from "@/lib/utils";
 import { usePrivy } from "@privy-io/react-auth";
+import dayjs from "dayjs";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import { useEffect, useState } from "react";
+import type { DateRange } from "react-day-picker";
 import Discord from "../../public/icons/discord.svg";
 import Github from "../../public/icons/github.svg";
 import Telegram from "../../public/icons/telegram.svg";
 import { Badge } from "./ui/badge";
 import { Skeleton } from "./ui/skeleton";
-import { DateRange } from "react-day-picker";
-import DatePickerWithPresets from "@/components/date-picker";
-import dayjs from 'dayjs';
 
 interface LeaderboardProps {
   data: LeaderboardEntry[] | null;
@@ -60,7 +60,7 @@ function LeaderboardHeader({
   metadata: any;
   selectedToken: { token: { id: string; name: string; symbol: string } };
 }) {
-  const t = useTranslations( "overview.leaderboard" );
+  const t = useTranslations("overview.leaderboard");
 
   return (
     <TableRow>
@@ -157,14 +157,14 @@ export default function Leaderboard({
   tokens,
   slug,
 }: LeaderboardProps) {
-  const {user} = usePrivy();
-  const t = useTranslations( "overview.leaderboard" );
-  const [localData, setLocalData] = useState<LeaderboardEntry[] | null>( data );
-  const [isLoading, setIsLoading] = useState( initialLoading );
-  const [date, setDate] = useState<DateRange | undefined>( {
+  const { user } = usePrivy();
+  const t = useTranslations("overview.leaderboard");
+  const [localData, setLocalData] = useState<LeaderboardEntry[] | null>(data);
+  const [isLoading, setIsLoading] = useState(initialLoading);
+  const [date, setDate] = useState<DateRange | undefined>({
     from: new Date(new Date().setDate(new Date().getDate() - 7)),
     to: new Date(),
-  } );
+  });
 
   // Filter tokens before using them
   const visibleTokens = filterVisibleTokens(tokens, metadata?.hidden_tokens);
@@ -260,8 +260,8 @@ export default function Leaderboard({
     </Table>
   );
 
-  useEffect( () => {
-    if (date && date.from && date.to) {
+  useEffect(() => {
+    if (date?.from && date?.to) {
       handleTokenSelect(selectedTokenId);
     }
   }, [date]);
@@ -269,7 +269,7 @@ export default function Leaderboard({
   return (
     <Card variant="borderless" className="h-full">
       <CardHeader>
-        <div className="flex items-end justify-between mb-4">
+        <div className="flex flex-col sm:flex-row sm:items-end justify-between mb-4 sm:mb-0 space-y-6 sm:space-y-0">
           <div className="space-y-2">
             <Label>{t("token")}</Label>
             <Select value={selectedTokenId} onValueChange={handleTokenSelect}>
@@ -285,8 +285,9 @@ export default function Leaderboard({
               </SelectContent>
             </Select>
           </div>
-          <div className="space-y-2">
-            <DatePickerWithPresets onDateChange={setDate}/>
+          <div className="flex flex-col space-y-4">
+            <Label>{t("datePicker.filterByDate")}</Label>
+            <DatePickerWithPresets onDateChange={setDate} />
           </div>
         </div>
       </CardHeader>

--- a/src/components/link-accounts.tsx
+++ b/src/components/link-accounts.tsx
@@ -99,9 +99,11 @@ export default function LinkAccounts() {
               <div className="flex items-center gap-1.5 min-w-0">
                 {service.icon}
                 <span className="truncate">
-                  {service.linkedAccount 
-                    ? service.linkedAccount
-                    : t('connect', { service: service.id })}
+                  {service.linkedAccount ? (
+                    <span>{service.linkedAccount}</span>
+                  ) : (
+                    <span className="capitalize">{t("connect", { service: service.id })}</span>
+                  )}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
### Problem  
When using the calendar, `date.to` was defaulting to the **start of the day** (`00:00:00`), which meant we were unintentionally excluding data/events that happened later that same day. This led to confusion, especially when reviewing ranges like "Last 7 Days".

The range presets (e.g. Last 7/30/90 days) also needed updating to be day-based, to remove ambiguity with ranges like "This Week"/"Last Week", which people define differently. This change allowed me to simplify the logic significantly.

### Updated  
- `date.to` now defaults to the **end of the day** (`23:59:59`) to ensure the entire date range is inclusive.  
- Updated range presets to be day-based (e.g. Last 7/30/90 days).  
- Removed special casing for "This Week"/"Last Week".  
- Simplified and unified date range logic across the board.
- **Extra:** Capitalised the platform names in `<LinkAccounts />`