### PR TITLE
fix: added internal avatar to component

### DIFF
--- a/src/components/impact-reports/sections/impact-report-avatar.tsx
+++ b/src/components/impact-reports/sections/impact-report-avatar.tsx
@@ -15,9 +15,9 @@ const sizeClasses = {
   lg: "h-12 w-12"
 };
 
-function Avatar({ className, children }: { className?: string; children: React.ReactNode }) {
+function Avatar({ size = "md", className, children }: { size?: "sm" | "md" | "lg"; className?: string; children: React.ReactNode }) {
   return (
-    <div className={cn("relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full", className)}>
+    <div className={cn("relative flex shrink-0 overflow-hidden rounded-full", sizeClasses[size], className)}>
       {children}
     </div>
   );

--- a/src/components/impact-reports/sections/impact-report-avatar.tsx
+++ b/src/components/impact-reports/sections/impact-report-avatar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
 
 interface ImpactReportAvatarProps {
   username: string;
@@ -14,6 +14,26 @@ const sizeClasses = {
   md: "h-10 w-10",
   lg: "h-12 w-12"
 };
+
+function Avatar({ className, children }: { className?: string; children: React.ReactNode }) {
+  return (
+    <div className={cn("relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full", className)}>
+      {children}
+    </div>
+  );
+}
+
+function AvatarImage({ src, alt }: { src: string; alt: string }) {
+  return <img src={src} alt={alt} className="aspect-square h-full w-full" />;
+}
+
+function AvatarFallback({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-full w-full items-center justify-center rounded-full bg-muted">
+      {children}
+    </div>
+  );
+}
 
 export function ImpactReportAvatar({ username, rank, size = "md" }: ImpactReportAvatarProps) {
   const initials = username


### PR DESCRIPTION
Problem: The impact report avatar component was trying to use a different Avatar component which didn't support children or the  AvatarImage and AvatarFallback components, causing type errors.
Solution: Implemented the necessary Avatar, AvatarImage, and AvatarFallback components directly in the impact report avatar file, making it self-contained and properly typed for the impact report