### PR TITLE
Feature/of 1012 fix broken metrics due to incorrect community identifier in

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -65,7 +65,7 @@ type Community = {
     };
   };
   communityContractAddress: Address;
-  communityContractChainId: Chain;
+  communityContractChainId: number;
   description: string;
   title: string;
   accentColor: string;

--- a/src/components/metrics-section.tsx
+++ b/src/components/metrics-section.tsx
@@ -32,18 +32,19 @@ export default function MetricsSection({ community }: MetricsSectionProps) {
     isFetching,
     refetch: refetchRewards,
   } = useQuery({
-    queryKey: ["rewards", community.communityContractAddress, page],
+    queryKey: ["rewards", community.communityContractAddress, community.communityContractChainId, page],
     queryFn: () =>
       fetchPaginatedRewardsByCommunity(
         community.communityContractAddress,
+        community.communityContractChainId,
         PAGE_SIZE,
         page * PAGE_SIZE,
       ),
   });
 
   const { data: rewardDistribution } = useQuery({
-    queryKey: ["rewardDistribution", community.communityContractAddress],
-    queryFn: () => fetchRewardDistributionMetrics(community.communityContractAddress),
+    queryKey: ["rewardDistribution", community.communityContractAddress, community.communityContractChainId],
+    queryFn: () => fetchRewardDistributionMetrics(community.communityContractAddress, community.communityContractChainId),
   });
 
   // Check if there might be more data
@@ -61,14 +62,20 @@ export default function MetricsSection({ community }: MetricsSectionProps) {
         {/* Unique Users Card */}
         <Card>
           <CardContent className="pt-6 px-6 pb-3">
-            <UniqueUsersChart appId={community.communityContractAddress} />
+            <UniqueUsersChart 
+              appId={community.communityContractAddress} 
+              chainId={community.communityContractChainId} 
+            />
           </CardContent>
         </Card>
 
         {/* Total Rewards Card */}
         <Card>
           <CardContent className="pt-6 px-6 pb-3">
-            <TotalRewardsChart appId={community.communityContractAddress} />
+            <TotalRewardsChart 
+              appId={community.communityContractAddress} 
+              chainId={community.communityContractChainId} 
+            />
           </CardContent>
         </Card>
 
@@ -77,6 +84,7 @@ export default function MetricsSection({ community }: MetricsSectionProps) {
           <CardContent className="pt-6 px-6 pb-3">
             <RewardDistributionChart
               appId={community.communityContractAddress}
+              chainId={community.communityContractChainId}
               data={rewardDistribution || null}
             />
           </CardContent>
@@ -92,6 +100,7 @@ export default function MetricsSection({ community }: MetricsSectionProps) {
           </div>
           <RewardIdsList
             appId={community.communityContractAddress}
+            chainId={community.communityContractChainId}
             data={rewardDistribution || null}
           />
         </div>

--- a/src/components/metrics/reward-distribution-chart.tsx
+++ b/src/components/metrics/reward-distribution-chart.tsx
@@ -15,6 +15,7 @@ import { desanitizeString } from "@/lib/utils";
 
 interface RewardDistributionChartProps {
   appId: string;
+  chainId: number;
   data: Record<string, RewardIdStats[]> | null;
 }
 
@@ -52,7 +53,7 @@ function getColor(index: number): string {
   return `hsl(${hue}, 85%, 55%)`;
 }
 
-export default function RewardDistributionChart({ appId, data }: RewardDistributionChartProps) {
+export default function RewardDistributionChart({ appId, chainId, data }: RewardDistributionChartProps) {
   const t = useTranslations('metrics.rewardDistribution');
   const [chartData, setChartData] = useState<ChartData[]>([]);
   const [isLoading, setIsLoading] = useState(true);

--- a/src/components/metrics/reward-ids-list.tsx
+++ b/src/components/metrics/reward-ids-list.tsx
@@ -119,9 +119,24 @@ export default function RewardIdsList({ appId, chainId, data }: RewardIdsListPro
     return (
       <Card>
         <CardContent className="p-6">
-          <div className="flex flex-col items-center justify-center h-[200px]">
-            <p className="text-muted-foreground">{t('noData')}</p>
-          </div>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t('rank')}</TableHead>
+                <TableHead>{t('rewardId')}</TableHead>
+                <TableHead>{t('totalCount')}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <TableRow>
+                <TableCell colSpan={3}>
+                  <div className="flex flex-col items-center justify-center py-8 text-center">
+                    <p className="text-muted-foreground">{t('noData')}</p>
+                  </div>
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
         </CardContent>
       </Card>
     );

--- a/src/components/metrics/reward-ids-list.tsx
+++ b/src/components/metrics/reward-ids-list.tsx
@@ -27,12 +27,13 @@ interface RewardData {
 
 interface RewardIdsListProps {
   appId: string;
+  chainId: number;
   data: Record<string, RewardIdStats[]> | null;
 }
 
 const ITEMS_PER_PAGE = 5;
 
-export default function RewardIdsList({ appId, data }: RewardIdsListProps) {
+export default function RewardIdsList({ appId, chainId, data }: RewardIdsListProps) {
   const t = useTranslations('metrics.rewards');
   const [formattedData, setFormattedData] = useState<RewardData[]>([]);
   const [isLoading, setIsLoading] = useState(true);

--- a/src/components/metrics/total-rewards-chart.tsx
+++ b/src/components/metrics/total-rewards-chart.tsx
@@ -17,6 +17,7 @@ import { startOfWeek, endOfWeek, format, isWithinInterval } from 'date-fns';
 
 interface TotalRewardsChartProps {
   appId: string;
+  chainId: number;
 }
 
 interface ChartData {
@@ -32,7 +33,7 @@ const TIME_RANGES = {
 
 type TimeRange = keyof typeof TIME_RANGES;
 
-export default function TotalRewardsChart({ appId }: TotalRewardsChartProps) {
+export default function TotalRewardsChart({ appId, chainId }: TotalRewardsChartProps) {
   const t = useTranslations('metrics.totalRewards');
   const [data, setData] = useState<ChartData[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -48,7 +49,7 @@ export default function TotalRewardsChart({ appId }: TotalRewardsChartProps) {
         const endTime = (now * 1000000).toString();
         const startTime = ((now - (TIME_RANGES[timeRange].days * 24 * 60 * 60)) * 1000000).toString();
         
-        const result = await fetchTotalRewardsMetricsWrapped(appId, startTime, endTime);
+        const result = await fetchTotalRewardsMetricsWrapped(appId, chainId, startTime, endTime);
         if (result) {
           let formattedData: { [key: string]: { value: number; displayName: string } } = {};
 
@@ -199,14 +200,17 @@ export default function TotalRewardsChart({ appId }: TotalRewardsChartProps) {
           setPercentageChange(0);
         }
       } catch (error) {
-        console.error('Error fetching total rewards data:', error);
+        console.error("Error fetching total rewards data:", error);
+        setData([]);
+        setTotalRewards(0);
+        setPercentageChange(0);
       } finally {
         setIsLoading(false);
       }
     }
 
     fetchData();
-  }, [appId, timeRange]);
+  }, [appId, chainId, timeRange]);
 
   if (isLoading) {
     return (

--- a/src/components/metrics/unique-users-chart.tsx
+++ b/src/components/metrics/unique-users-chart.tsx
@@ -16,6 +16,7 @@ import { Area, AreaChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "rec
 
 interface UniqueUsersChartProps {
   appId: string;
+  chainId: number;
 }
 
 const TIME_RANGES = {
@@ -26,7 +27,7 @@ const TIME_RANGES = {
 
 type TimeRange = keyof typeof TIME_RANGES;
 
-export default function UniqueUsersChart({ appId }: UniqueUsersChartProps) {
+export default function UniqueUsersChart({ appId, chainId }: UniqueUsersChartProps) {
   const t = useTranslations("metrics.uniqueUsers");
   const [data, setData] = useState<any[]>([]);
   const [totalUsers, setTotalUsers] = useState(0);
@@ -43,7 +44,7 @@ export default function UniqueUsersChart({ appId }: UniqueUsersChartProps) {
 
     const fetchData = async () => {
       setIsLoading(true);
-      const result = await fetchUniqueUsersMetricsWrapped(appId, startTime, endTime);
+      const result = await fetchUniqueUsersMetricsWrapped(appId, chainId, startTime, endTime);
       if (result) {
         let formattedData: { [key: string]: { users: number; displayName: string } } = {};
 
@@ -189,7 +190,7 @@ export default function UniqueUsersChart({ appId }: UniqueUsersChartProps) {
     };
 
     fetchData();
-  }, [appId, timeRange]);
+  }, [appId, chainId, timeRange]);
 
   if (isLoading) {
     return (

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -1,6 +1,6 @@
 import { request } from "graphql-request";
 import { cache } from "react";
-import { getChainFromCommunityOrCookie } from "./openformat";
+import { getChainById } from "@/constants/chains";
 
 interface MetricDataPoint {
   timestamp: string;
@@ -28,10 +28,11 @@ interface RewardStatsResponse {
 export const fetchUniqueUsersMetrics = cache(
   async (
     appId: string,
+    chainId: number,
     startTime?: string,
     endTime?: string,
   ): Promise<MetricDataPoint[] | null> => {
-    const chain = await getChainFromCommunityOrCookie(appId);
+    const chain = getChainById(chainId);
     if (!chain) return null;
 
     const query = `
@@ -72,10 +73,11 @@ export const fetchUniqueUsersMetrics = cache(
 export const fetchTotalRewardsMetrics = cache(
   async (
     appId: string,
+    chainId: number,
     startTime?: string,
     endTime?: string,
   ): Promise<MetricDataPoint[] | null> => {
-    const chain = await getChainFromCommunityOrCookie(appId);
+    const chain = getChainById(chainId);
     if (!chain) return null;
 
     // @TODO: Add pagination to get all data
@@ -115,8 +117,8 @@ export const fetchTotalRewardsMetrics = cache(
 );
 
 export const fetchRewardDistributionMetrics = cache(
-  async (appId: string): Promise<Record<string, RewardIdStats[]> | null> => {
-    const chain = await getChainFromCommunityOrCookie(appId);
+  async (appId: string, chainId: number): Promise<Record<string, RewardIdStats[]> | null> => {
+    const chain = getChainById(chainId);
     if (!chain) return null;
 
     const rewardIdsQuery = `
@@ -292,23 +294,25 @@ const shouldUseTestData = process.env.NEXT_PUBLIC_USE_TEST_DATA === "true";
 export const fetchTotalRewardsMetricsWrapped = cache(
   async (
     appId: string,
+    chainId: number,
     startTime?: string,
     endTime?: string,
   ): Promise<MetricDataPoint[] | null> => {
     return shouldUseTestData
       ? fetchTotalRewardsMetricsTest(appId, startTime, endTime)
-      : fetchTotalRewardsMetrics(appId, startTime, endTime);
+      : fetchTotalRewardsMetrics(appId, chainId, startTime, endTime);
   },
 );
 
 export const fetchUniqueUsersMetricsWrapped = cache(
   async (
     appId: string,
+    chainId: number,
     startTime?: string,
     endTime?: string,
   ): Promise<MetricDataPoint[] | null> => {
     return shouldUseTestData
       ? fetchUniqueUsersMetricsTest(appId, startTime, endTime)
-      : fetchUniqueUsersMetrics(appId, startTime, endTime);
+      : fetchUniqueUsersMetrics(appId, chainId, startTime, endTime);
   },
 );

--- a/src/lib/openformat.ts
+++ b/src/lib/openformat.ts
@@ -137,9 +137,17 @@ export async function fetchAllCommunities() {
 export const fetchCommunity = cache(async (slugOrId: string) => {
   const communityFromDb = await getCommunity(slugOrId);
 
-  const chain = await getChainFromCommunityOrCookie(slugOrId);
-
   if (!communityFromDb) {
+    return null;
+  }
+
+  if (!communityFromDb.communityContractChainId || !communityFromDb.communityContractAddress) {
+    return null;
+  }
+
+  const chain = getChainById(communityFromDb.communityContractChainId);
+
+  if (!chain) {
     return null;
   }
 
@@ -179,9 +187,9 @@ query ($app: ID!) {
         badges: { id: string }[];
         tokens: Token[];
       };
-    }>(chain.SUBGRAPH_URL, query, { app: communityFromDb.id });
+    }>(chain.SUBGRAPH_URL, query, { app: communityFromDb.communityContractAddress });
 
-    const rewards = await fetchAllRewardsByCommunity(communityFromDb.id);
+    const rewards = await fetchAllRewardsByCommunity(communityFromDb.communityContractAddress, communityFromDb.communityContractChainId);
 
     return {
       ...data.app,
@@ -194,8 +202,8 @@ query ($app: ID!) {
   }
 });
 
-async function fetchAllRewardsByCommunity(communityId: string): Promise<Reward[] | null> {
-  const chain = await getChainFromCommunityOrCookie();
+async function fetchAllRewardsByCommunity(communityId: string, chainId: number): Promise<Reward[] | null> {
+  const chain = getChainById(chainId);
 
   if (!chain) {
     return null;
@@ -404,10 +412,14 @@ export async function generateLeaderboard(
       return { data: [], error: "Community not found" };
     }
 
-    const selectedTokenId = tokenId || communityFromDb.token_to_display || "";
+    if (!communityFromDb.communityContractAddress) {
+      return { data: [], error: "Community contract address not found" };
+    }
+
+    const selectedTokenId = tokenId || communityFromDb.tokenToDisplay || "";
 
     const params = new URLSearchParams();
-    params.set("app_id", communityFromDb.id);
+    params.set("app_id", communityFromDb.communityContractAddress);
     params.set("token_id", selectedTokenId);
     params.set("start", startDate);
     params.set("end", endDate);

--- a/src/lib/openformat.ts
+++ b/src/lib/openformat.ts
@@ -238,11 +238,12 @@ async function fetchAllRewardsByCommunity(communityId: string): Promise<Reward[]
 }
 
 export async function fetchPaginatedRewardsByCommunity(
-  communityId: string,
+  appId: string,
+  chainId: number,
   first: number,
   skip: number,
 ): Promise<Reward[] | null> {
-  const chain = await getChainFromCommunityOrCookie();
+  const chain = getChainById(chainId);
 
   if (!chain) {
     return null;
@@ -289,7 +290,7 @@ export async function fetchPaginatedRewardsByCommunity(
 
   const data = await request<{
     rewards: Reward[];
-  }>(chain.SUBGRAPH_URL, query, { first, skip, appId: communityId });
+  }>(chain.SUBGRAPH_URL, query, { first, skip, appId });
 
   return data.rewards;
 }


### PR DESCRIPTION
Problem

The community-platform frontend was using the old appId instead of the community's on-chain contract address and chain ID for querying external APIs/subgraphs. This caused metrics charts, activity lists, and token creation to fail when communities had contract addresses.

Solution

Frontend: Updated metrics components, API calls, and token creation flow to use communityContractAddress and communityContractChainId instead of the old appId
Backend: Fixed missing API schema fields in community-agent that were causing updateCommunity calls to fail

Key Changes

Updated fetchCommunity, fetchPaginatedRewardsByCommunity functions
Modified all chart components to accept and use chainId parameter
Updated metrics fetching functions to use getChainById(chainId)
Token Creation: Fixed CreateTokenForm to use contract address/chain ID for app creation and updates

Agent: Added missing communityContractAddress, communityContractChainId, and hiddenTokens fields to API schema