### PR TITLE
Feature/of 1004 client error when exporting activity with no data

### DIFF
--- a/src/components/metrics/total-rewards-chart.tsx
+++ b/src/components/metrics/total-rewards-chart.tsx
@@ -315,8 +315,25 @@ export default function TotalRewardsChart({ appId, chainId }: TotalRewardsChartP
               tickFormatter={(value) => value.toLocaleString()}
             />
             <Tooltip
-              formatter={(value: number) => [value.toLocaleString(), t('rewards')]}
-              labelFormatter={(label) => label}
+              content={({ active, payload, label }) => {
+                if (active && payload && payload.length) {
+                  return (
+                    <div className="rounded-lg border bg-background p-2 shadow-sm">
+                      <div className="grid gap-2">
+                        <div className="flex flex-col">
+                          <span className="text-[0.70rem] uppercase text-muted-foreground">
+                            {label}
+                          </span>
+                          <span className="font-bold">
+                            {payload[0]?.value?.toLocaleString()} {t('rewards')}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                }
+                return null;
+              }}
             />
             <Bar 
               dataKey="value" 

--- a/src/components/token-selector.tsx
+++ b/src/components/token-selector.tsx
@@ -50,7 +50,7 @@ export default function TokenSelector({
       value &&
       !(includeAllOption && value === "All") &&
       !tokens.some((token) => token.token.id === value) &&
-      !badges.some((badge) => badge.id === value)
+      !(badges && badges.some((badge) => badge.id === value))
     ) {
       onChange("");
     }
@@ -61,7 +61,7 @@ export default function TokenSelector({
     onChange(currentValue);
 
     if (onTokenTypeChange) {
-      const isBadge = badges.some((badge) => badge.id === currentValue);
+      const isBadge = badges && badges.some((badge) => badge.id === currentValue);
       console.log("Is Badge:", isBadge);
       onTokenTypeChange(isBadge, currentValue);
     }
@@ -81,7 +81,7 @@ export default function TokenSelector({
 
   const getDisplayValue = () => {
     // Debug the display value calculation
-    const selectedBadge = badges.find((badge) => badge.id === value);
+    const selectedBadge = badges && badges.find((badge) => badge.id === value);
     const selectedToken = tokens.find((item) => item.token?.id === value);
 
     if (selectedBadge) {
@@ -169,7 +169,7 @@ export default function TokenSelector({
               ))}
             </CommandGroup>
             <CommandSeparator />
-            {badges.length > 0 && (
+            {badges && badges.length > 0 && (
               <CommandGroup heading={t("badges")}>
                 {badges.map((item) => (
                   <CommandItem

--- a/src/forms/activity-export-form.tsx
+++ b/src/forms/activity-export-form.tsx
@@ -98,6 +98,10 @@ export function ActivityExportForm({ community }: ActivityExportFormProps) {
   const startDateWatch = form.watch("startDate");
   const endDateWatch = form.watch("endDate");
 
+  const hasTokens = community.onchainData?.tokens && community.onchainData.tokens.length > 0;
+  const hasBadges = community.onchainData?.badges && community.onchainData.badges.length > 0;
+  const hasData = hasTokens || hasBadges;
+
   return (
     <Form {...form}>
       <form className="w-full space-y-8" onSubmit={form.handleSubmit(handleFormSubmission)}>
@@ -231,8 +235,8 @@ export function ActivityExportForm({ community }: ActivityExportFormProps) {
               <FormControl>
                 <TokenSelector
                   forceModal={true}
-                  tokens={community.tokens}
-                  badges={community.badges}
+                  tokens={community.onchainData?.tokens || []}
+                  badges={community.onchainData?.badges || []}
                   value={field.value ?? ""}
                   includeAllOption={true}
                   onChange={field.onChange}
@@ -251,7 +255,7 @@ export function ActivityExportForm({ community }: ActivityExportFormProps) {
             </FormItem>
           )}
         />
-        <Button type="submit" disabled={isLoading}>
+        <Button type="submit" disabled={isLoading || !hasData}>
           {isLoading ? t("exportingLabel") : t("exportLabel")}
         </Button>
       </form>


### PR DESCRIPTION
Problem: Client error when exporting activity from communities without tokens/badges.
Solution: Added null checks for badges array in TokenSelector and fixed property access in export form.

additionally updated styling of hover state for rewards graph