### PR TITLE
refactor: fix onboarding flow routing when Telegram connected second

### DIFF
--- a/src/app/api/discord/callback/route.ts
+++ b/src/app/api/discord/callback/route.ts
@@ -29,34 +29,41 @@ function createErrorRedirect(error: string, req: NextRequest) {
   );
 }
 
-async function getOrCreateCommunity(communityId: string | undefined, existingPlatformConnection: PlatformConnection | null = null) {
-  if (existingPlatformConnection?.communityId) {
-    const community = await agentApiClient
-      .get(`/communities/${existingPlatformConnection.communityId}`)
-      .then((res) => res.data);
-    return { community, communityId: existingPlatformConnection.communityId, isNewCommunity: false };
-  }
+async function getOrCreateCommunity(
+	communityId: string | undefined,
+	existingPlatformConnection: PlatformConnection | null = null,
+) {
+	if (existingPlatformConnection?.communityId) {
+		const community = await agentApiClient
+			.get(`/communities/${existingPlatformConnection.communityId}`)
+			.then((res) => res.data);
+		return {
+			community,
+			communityId: existingPlatformConnection.communityId,
+			isNewCommunity: false,
+		};
+	}
 
-  if (communityId) {
-    try {
-      const community = await agentApiClient
-        .get(`/communities/${communityId}`)
-        .then((res) => res.data);
-      return { community, communityId, isNewCommunity: false };
-    } catch (error) {
-      console.warn("Stored community not found, creating new community");
-    }
-  }
+	if (communityId) {
+		try {
+			const community = await agentApiClient
+				.get(`/communities/${communityId}`)
+				.then((res) => res.data);
+			return { community, communityId, isNewCommunity: false };
+		} catch (error) {
+			console.warn("Stored community not found, creating new community");
+		}
+	}
 
-  const community = await agentApiClient
-    .post("/communities", { name: "Community" })
-    .then((res) => res.data);
+	const community = await agentApiClient
+		.post("/communities", { name: "Community" })
+		.then((res) => res.data);
 
-  if (!community.id || typeof community.id !== "string") {
-    throw new Error("Community creation failed");
-  }
+	if (!community.id || typeof community.id !== "string") {
+		throw new Error("Community creation failed");
+	}
 
-  return { community, communityId: community.id, isNewCommunity: true };
+	return { community, communityId: community.id, isNewCommunity: true };
 }
 
 async function setupUserAndRole(did: string, communityId: string) {
@@ -113,30 +120,40 @@ export async function GET(req: NextRequest) {
 
     let existingPlatformConnection: PlatformConnection | null = null;
     try {
-      const platformResponse = await agentApiClient.get(`/platform-connections/by-platform-id/discord/${guildId}`);
+      const platformResponse = await agentApiClient.get(
+							`/platform-connections/by-platform-id/discord/${guildId}`,
+						);
       existingPlatformConnection = platformResponse.data;
     } catch (error) {
       if (isAxiosError(error) && error.response?.status === 404) {
         console.log("No existing platform connection found for guild:", guildId);
       } else {
         console.error("Error checking for existing platform connection:", {
-          guildId,
-          error: error instanceof Error ? error.message : String(error),
-          status: isAxiosError(error) ? error.response?.status : 'unknown'
-        });
+									guildId,
+									error: error instanceof Error ? error.message : String(error),
+									status: isAxiosError(error)
+										? error.response?.status
+										: "unknown",
+								});
       }
     }
 
     // Get or create community
-    const { community, communityId, isNewCommunity } = await getOrCreateCommunity(
-      stateCommunityId || storedCommunityId,
-      existingPlatformConnection
-    );
+				const { community, communityId, isNewCommunity } =
+					await getOrCreateCommunity(
+						stateCommunityId || storedCommunityId,
+						existingPlatformConnection,
+					);
 
     // Update platform connection
     try {
       if (existingPlatformConnection) {
-        await agentApiClient.put(`/platform-connections/${existingPlatformConnection.id}`, { communityId });
+        await agentApiClient.put(
+									`/platform-connections/${existingPlatformConnection.id}`,
+									{
+										communityId,
+									},
+								);
       } else {
         await agentApiClient.put(`/platform-connections/${guildId}`, { communityId });
       }
@@ -157,7 +174,7 @@ export async function GET(req: NextRequest) {
         return community;
       });
 
-    const redirectUrl = `${process.env.PLATFORM_BASE_URL}/onboarding/integrations?success=true&guildId=${guildId}&communityId=${communityId}&isNew=${isNewCommunity}`;
+    const redirectUrl = `${process.env.PLATFORM_BASE_URL}/onboarding/integrations?success=true&guildId=${guildId}&communityId=${communityId}&isNew=${isNewCommunity}&firstConnection=${!existingPlatformConnection?.communityId}`;
 
     const response = NextResponse.redirect(new URL(redirectUrl, req.url));
 

--- a/src/app/api/telegram/callback/route.ts
+++ b/src/app/api/telegram/callback/route.ts
@@ -158,7 +158,7 @@ export async function GET(req: NextRequest) {
         console.error("Failed to mark verification code as used:", error);
       }
 
-      const redirectUrl = `${process.env.PLATFORM_BASE_URL}/onboarding/integrations?success=true&platformId=${existingPlatformConnection?.platformId || platformConnectionId}&communityId=${communityId}&isNew=${isNewCommunity}`;
+      const redirectUrl = `${process.env.PLATFORM_BASE_URL}/onboarding/integrations?success=true&platformId=${existingPlatformConnection?.platformId || platformConnectionId}&communityId=${communityId}&isNew=${isNewCommunity}&firstConnection=${!existingPlatformConnection?.communityId}`;
 
       const nextResponse = NextResponse.redirect(new URL(redirectUrl, req.url));
 
@@ -241,7 +241,7 @@ export async function GET(req: NextRequest) {
         return community;
       });
 
-    const redirectUrl = `${process.env.PLATFORM_BASE_URL}/onboarding/integrations?success=true&platformId=${existingPlatformConnection?.platformId || platformConnectionId}&communityId=${communityId}&isNew=${isNewCommunity}`;
+    const redirectUrl = `${process.env.PLATFORM_BASE_URL}/onboarding/integrations?success=true&platformId=${existingPlatformConnection?.platformId || platformConnectionId}&communityId=${communityId}&isNew=${isNewCommunity}&firstConnection=${!existingPlatformConnection?.communityId}`;
 
     const response = NextResponse.redirect(new URL(redirectUrl, req.url));
 

--- a/src/app/onboarding/setup/setup-client.tsx
+++ b/src/app/onboarding/setup/setup-client.tsx
@@ -5,7 +5,14 @@ import { Button } from "@/components/ui/button";
 import config from "@/constants/config";
 import { usePollingJob } from "@/hooks/useJobStatus";
 import { usePrivy } from "@privy-io/react-auth";
-import { AlertCircle, CheckCircle, Loader2, SkipForward, FileText, BarChart2 } from "lucide-react";
+import {
+  AlertCircle,
+  CheckCircle,
+  Loader2,
+  SkipForward,
+  FileText,
+  BarChart2,
+} from "lucide-react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -13,7 +20,13 @@ import posthog from "posthog-js";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
-type JobStatus = "idle" | "pending" | "processing" | "completed" | "failed" | "skipped";
+type JobStatus =
+  | "idle"
+  | "pending"
+  | "processing"
+  | "completed"
+  | "failed"
+  | "skipped";
 
 export default function SetupClient() {
   const t = useTranslations("onboarding.setup");
@@ -27,7 +40,9 @@ export default function SetupClient() {
 
   const [messagesJobId, setMessagesJobId] = useState<string | null>(null);
   const [reportJobId, setReportJobId] = useState<string | null>(null);
-  const [recommendationsJobId, setRecommendationsJobId] = useState<string | null>(null);
+  const [recommendationsJobId, setRecommendationsJobId] = useState<
+    string | null
+  >(null);
   const jobsStartedRef = useRef(false);
   const eventFiredRef = useRef({
     fetchHistoricalMessages: false,
@@ -38,7 +53,8 @@ export default function SetupClient() {
   const [hasLowActivity, setHasLowActivity] = useState(false);
 
   const { status: messagesStatus, data: messagesData } = usePollingJob({
-    statusEndpoint: (jobId) => `/api/onboarding/messages-job-status?jobId=${jobId}`,
+    statusEndpoint: (jobId) =>
+      `/api/onboarding/messages-job-status?jobId=${jobId}`,
     initialJobId: messagesJobId || undefined,
     onStatusChange: (status, message) => {
       if (status === "failed") {
@@ -48,7 +64,8 @@ export default function SetupClient() {
   });
 
   const { status: reportStatus } = usePollingJob({
-    statusEndpoint: (jobId) => `/api/onboarding/report-job-status?jobId=${jobId}`,
+    statusEndpoint: (jobId) =>
+      `/api/onboarding/report-job-status?jobId=${jobId}`,
     initialJobId: reportJobId || undefined,
     onStatusChange: (status, message) => {
       if (status === "failed") {
@@ -58,7 +75,8 @@ export default function SetupClient() {
   });
 
   const { status: recommendationsStatus } = usePollingJob({
-    statusEndpoint: (jobId) => `/api/onboarding/recommendations-job-status?jobId=${jobId}`,
+    statusEndpoint: (jobId) =>
+      `/api/onboarding/recommendations-job-status?jobId=${jobId}`,
     initialJobId: recommendationsJobId || undefined,
     onStatusChange: (status, message) => {
       if (status === "failed") {
@@ -69,17 +87,20 @@ export default function SetupClient() {
 
   const { startJobAsync: startMessagesJobAsync } = usePollingJob({
     startJobEndpoint: "/api/onboarding/start-messages-job",
-    statusEndpoint: (jobId) => `/api/onboarding/messages-job-status?jobId=${jobId}`,
+    statusEndpoint: (jobId) =>
+      `/api/onboarding/messages-job-status?jobId=${jobId}`,
   });
 
   const { startJobAsync: startReportJobAsync } = usePollingJob({
     startJobEndpoint: "/api/onboarding/start-report-job",
-    statusEndpoint: (jobId) => `/api/onboarding/report-job-status?jobId=${jobId}`,
+    statusEndpoint: (jobId) =>
+      `/api/onboarding/report-job-status?jobId=${jobId}`,
   });
 
   const { startJobAsync: startRecommendationsJobAsync } = usePollingJob({
     startJobEndpoint: "/api/onboarding/start-recommendations-job",
-    statusEndpoint: (jobId) => `/api/onboarding/recommendations-job-status?jobId=${jobId}`,
+    statusEndpoint: (jobId) =>
+      `/api/onboarding/recommendations-job-status?jobId=${jobId}`,
   });
 
   // Start the initial messages job when component mounts
@@ -117,7 +138,10 @@ export default function SetupClient() {
 
         try {
           const [reportResponse, recommendationsResponse] = await Promise.all([
-            startReportJobAsync?.({ platformId: guildId, communityId }),
+            startReportJobAsync?.({
+              platformId: guildId,
+              communityId,
+            }),
             startRecommendationsJobAsync?.({
               platformId: guildId,
               communityId,
@@ -152,7 +176,9 @@ export default function SetupClient() {
 
   const isComplete =
     messagesStatus === "completed" &&
-    (hasLowActivity ? true : reportStatus === "completed" && recommendationsStatus === "completed");
+    (hasLowActivity
+      ? true
+      : reportStatus === "completed" && recommendationsStatus === "completed");
 
   // Add loading state for continue button
   const isContinueLoading =
@@ -176,7 +202,10 @@ export default function SetupClient() {
   };
 
   // Progress bar steps
-  const progressSteps = [{ label: "Connect your community" }, { label: "Setting up your Copilot" }];
+  const progressSteps = [
+    { label: "Connect your community" },
+    { label: "Setting up your Copilot" },
+  ];
 
   // Status card steps
   const statusSteps = [
@@ -244,7 +273,9 @@ export default function SetupClient() {
       case "skipped":
         return <SkipForward className="h-5 w-5 text-yellow-500" />;
       default:
-        return <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />;
+        return (
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        );
     }
   };
 
@@ -267,7 +298,9 @@ export default function SetupClient() {
     }
   };
 
-  const handleRetry = async (jobType: "report" | "recommendations" | "messages") => {
+  const handleRetry = async (
+    jobType: "report" | "recommendations" | "messages",
+  ) => {
     try {
       if (jobType === "messages") {
         if (!guildId) throw new Error("Missing guildId");
@@ -290,7 +323,8 @@ export default function SetupClient() {
           throw new Error("Failed to start report job");
         }
       } else {
-        if (!guildId || !communityId) throw new Error("Missing guildId or communityId");
+        if (!guildId || !communityId)
+          throw new Error("Missing guildId or communityId");
         const recommendationsResponse = await startRecommendationsJobAsync?.({
           platformId: guildId,
           communityId,
@@ -317,11 +351,20 @@ export default function SetupClient() {
         scroll: false,
       });
     }
-  }, [reportStatus, recommendationsStatus, messagesStatus, router, searchParams]);
+  }, [
+    reportStatus,
+    recommendationsStatus,
+    messagesStatus,
+    router,
+    searchParams,
+  ]);
 
   // Fire fetch_historical_messages_complete when messagesStatus transitions to completed
   useEffect(() => {
-    if (messagesStatus === "completed" && !eventFiredRef.current.fetchHistoricalMessages) {
+    if (
+      messagesStatus === "completed" &&
+      !eventFiredRef.current.fetchHistoricalMessages
+    ) {
       posthog.capture?.("fetch_historical_messages_complete", {
         userId: user?.id || null,
         communityId: communityId || null,
@@ -332,7 +375,10 @@ export default function SetupClient() {
 
   // Fire reward_recommendations_generated when recommendationsStatus transitions to completed
   useEffect(() => {
-    if (recommendationsStatus === "completed" && !eventFiredRef.current.rewardRecommendations) {
+    if (
+      recommendationsStatus === "completed" &&
+      !eventFiredRef.current.rewardRecommendations
+    ) {
       posthog.capture?.("reward_recommendations_generated", {
         userId: user?.id || null,
         communityId: communityId || null,
@@ -343,7 +389,10 @@ export default function SetupClient() {
 
   // Fire community_snapshot_generated when reportStatus transitions to completed
   useEffect(() => {
-    if (reportStatus === "completed" && !eventFiredRef.current.communitySnapshot) {
+    if (
+      reportStatus === "completed" &&
+      !eventFiredRef.current.communitySnapshot
+    ) {
       posthog.capture?.("community_snapshot_generated", {
         userId: user?.id || null,
         communityId: communityId || null,
@@ -357,7 +406,10 @@ export default function SetupClient() {
     return (
       <>
         <div className="mb-8">
-          <OnboardingProgressBar steps={progressSteps} progresses={progresses} />
+          <OnboardingProgressBar
+            steps={progressSteps}
+            progresses={progresses}
+          />
         </div>
         <div className="w-full max-w-2xl bg-zinc-900 rounded-2xl shadow-lg p-8 border border-zinc-800">
           <div className="flex flex-col gap-8">
@@ -368,8 +420,8 @@ export default function SetupClient() {
               </h2>
               <div className="flex flex-col space-y-4 items-center text-center">
                 <p>
-                  Your Copilot is busy listening and learning in your Telegram. Impact reports and
-                  reward recommendations are updated daily.
+                  Your Copilot is busy listening and learning in your Telegram.
+                  Impact reports and reward recommendations are updated daily.
                 </p>
                 <p>
                   Want to expand your insights?{" "}
@@ -379,7 +431,8 @@ export default function SetupClient() {
                   >
                     Connect your Discord server
                   </Link>{" "}
-                  to instantly generate impact reports and reward recommendations!
+                  to instantly generate impact reports and reward
+                  recommendations!
                 </p>
               </div>
             </div>
@@ -439,10 +492,16 @@ export default function SetupClient() {
                       : "opacity-90"
                 }`}
               >
-                <div className="flex-shrink-0 mt-1">{getStatusIcon(step.status)}</div>
+                <div className="flex-shrink-0 mt-1">
+                  {getStatusIcon(step.status)}
+                </div>
                 <div className="flex-1">
-                  <div className="font-semibold text-white mb-0.5">{step.title}</div>
-                  <div className="text-gray-400 text-sm mb-1">{step.description}</div>
+                  <div className="font-semibold text-white mb-0.5">
+                    {step.title}
+                  </div>
+                  <div className="text-gray-400 text-sm mb-1">
+                    {step.description}
+                  </div>
                   <div className="flex items-center justify-between">
                     <div className="text-xs text-gray-500">
                       {step.isJob
@@ -474,10 +533,15 @@ export default function SetupClient() {
           {isComplete && (
             <>
               <div className="bg-zinc-800/70 rounded-xl p-6 mt-4 border border-zinc-700">
-                <div className="font-semibold text-white mb-3">What's Next?</div>
+                <div className="font-semibold text-white mb-3">
+                  What's Next?
+                </div>
                 <ul className="space-y-2">
                   {whatsNext.map((item) => (
-                    <li key={item} className="flex items-center gap-2 text-gray-300 text-sm">
+                    <li
+                      key={item}
+                      className="flex items-center gap-2 text-gray-300 text-sm"
+                    >
                       <CheckCircle className="h-4 w-4 text-yellow-400" />
                       {item}
                     </li>
@@ -492,7 +556,9 @@ export default function SetupClient() {
                       userId: user?.id || null,
                       communityId: searchParams.get("communityId") || null,
                     });
-                    router.push(`/communities/${searchParams.get("communityId")}`);
+                    router.push(
+                      `/communities/${searchParams.get("communityId")}`,
+                    );
                   }}
                   disabled={isContinueLoading}
                 >


### PR DESCRIPTION
Problem
When users connect Discord first and then Telegram second, the onboarding flow incorrectly shows the "Telegram-only" message instead of the jobs loading screen. This happens because the setup page relies on a guildId URL parameter that's missing when Telegram is connected second.

Root Cause
Discord callback sets guildId as HTTP-only cookie (not accessible client-side)
Setup page expects guildId in URL parameters
When Telegram is connected second, the guildId is not passed to the setup page
This causes the setup page to show the wrong screen

Solution
Extract Discord guildId from community.platformConnections in integrations client
Pass guildId via URL parameters to setup page
Remove debugging console.log statements and unused imports
Ensure onboarding flow works correctly regardless of platform connection order

Files Changed
src/app/onboarding/integrations/integrations-client.tsx
src/app/onboarding/setup/setup-client.tsx

Testing
✅ Discord first, Telegram second → Shows jobs loading screen
✅ Telegram first, Discord second → Shows jobs loading screen
✅ New communities → Routes to setup correctly
✅ Existing communities → Routes to overview correctly
Impact
Users can now connect platforms in any order and see the correct onboarding screens, improving the user experience and reducing confusion during community setup.
